### PR TITLE
Update the CircleCI config to use the Python Orb version 1.4.0

### DIFF
--- a/circleci/config.yml
+++ b/circleci/config.yml
@@ -1,3 +1,4 @@
+version: 2.1
 jobs:
   build:
     executor: python/default
@@ -17,8 +18,7 @@ jobs:
             poetry run pytest
           name: Run Tests
 orbs:
-  python: circleci/python@1.3.2
-version: 2.1
+  python: circleci/python@1.4.0
 workflows:
   main:
     jobs:


### PR DESCRIPTION
The CircleCI `config.yml` file has been updated to use the Python Orb version 1.4.0.